### PR TITLE
Bugfix - use the subset of COMPASS_POINTS according to the depth option

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -72,6 +72,14 @@ describe('Windrose', function () {
           done();
         });
 
+        it('should return N when passing 359 degrees with 2 depth', function (done) {
+          var res = Windrose.getPoint(359, { depth: 2 });
+          expect(res).to.be.an('object');
+          expect(res.symbol).to.equal('N');
+
+          done();
+        });
+
         it('should return undefined when passing invalid depth', function (done) {
           var res = Windrose.getPoint(15, { depth: 0 });
           expect(res).to.be.an('object');

--- a/windrose.js
+++ b/windrose.js
@@ -85,15 +85,17 @@
             opts = opts || {};
             opts.depth = opts.hasOwnProperty('depth') ? opts.depth : 3;
 
-            var idx = Math.round(degrees / DEPTHS_AREA[opts.depth]);
+            var idx = Math.round(degrees / DEPTHS_AREA[opts.depth]),
+                _compass_points = COMPASS_POINTS.filter(function(pt)
+                {
+                    return pt.depth <= opts.depth;
+                });
 
             // 360 === 0 aka North
-            if (idx === COMPASS_POINTS.length) {
+            if (idx === _compass_points.length) {
                 idx = 0;
             }
-            return COMPASS_POINTS.filter(function (pt) {
-                return pt.depth <= opts.depth;
-            })[idx];
+            return _compass_points[idx];
         },
 
         /**


### PR DESCRIPTION
Hey,

I've come across your tool and I've found a small bug within the `getPoint` function.

Have a look at the proposed solution - also added a test.

Cheers